### PR TITLE
Included handling of overlapping variants to be consistent with bcftools consensus' output

### DIFF
--- a/src/vcf.cpp
+++ b/src/vcf.cpp
@@ -106,6 +106,7 @@ vcfbwt::Sample::iterator::operator++()
         }
 
         bool get_next_variant = true;
+        bool iterate = false;
 
         if (curr_var_it_ < curr_variation.alt[var_genotype].size() - 1)
         {
@@ -116,7 +117,7 @@ vcfbwt::Sample::iterator::operator++()
         else if (curr_var_it_ < curr_variation.alt[var_genotype].size())
             curr_char_ = &curr_variation.alt[var_genotype].back();
         else
-            curr_char_ = &(sample_.reference_[ref_it_++ + curr_variation.ref_len - gap]);
+            iterate = true; // We evaluate the next position that might be either on the reference or another variation
 
         sam_it_++;
         if (get_next_variant)
@@ -130,6 +131,8 @@ vcfbwt::Sample::iterator::operator++()
             curr_var_it_ = 0;
             ref_it_ += curr_variation.ref_len - gap; // Adding -gap to balance the sipping
         }
+
+        if (iterate) this->operator++();
     }
     // Non ci sono più variazioni, itera sulla reference
     else { curr_char_ = &(sample_.reference_[ref_it_]); ref_it_++; sam_it_++; }

--- a/tests/unit_tests.cpp
+++ b/tests/unit_tests.cpp
@@ -493,6 +493,45 @@ TEST_CASE( "Constructor", "[VCF parser]" )
     REQUIRE(all_match);
 }
 
+TEST_CASE("Sample: HG00101", "[VCF parser]")
+{
+    std::string vcf_file_name = testfiles_dir + "/ALL.chrY.phase3_integrated_v2a.20130502.genotypes.vcf.gz";
+    std::string ref_file_name = testfiles_dir + "/Y.fa.gz";
+    vcfbwt::VCF vcf(ref_file_name, vcf_file_name, "", 2);
+
+    REQUIRE(vcf[1].id() == "HG00101");
+
+    std::string test_sample_path = testfiles_dir + "/HG00101_chrY_H1.fa.gz";
+    std::ifstream in_stream(test_sample_path);
+
+    REQUIRE(vcfbwt::is_gzipped(in_stream));
+
+    zstr::istream is(in_stream);
+    std::string line, from_fasta;
+    while (getline(is, line))
+    {
+        if (not(line.empty() or line[0] == '>'))
+        {
+            from_fasta.append(line);
+        }
+    }
+
+    vcfbwt::Sample::iterator it(vcf[1]);
+    std::string from_vcf;
+    while (not it.end())
+    {
+        from_vcf.push_back(*it);
+        ++it;
+    }
+
+    std::size_t i = 0;
+    while (((i < from_vcf.size()) and (i < from_fasta.size())) and (from_vcf[i] == from_fasta[i]))
+    {
+        i++;
+    }
+    REQUIRE(((i == (from_vcf.size())) and (i == (from_fasta.size()))));
+}
+
 TEST_CASE( "Sample: HG00103", "[VCF parser]" )
 {
     std::string vcf_file_name = testfiles_dir + "/ALL.chrY.phase3_integrated_v2a.20130502.genotypes.vcf.gz";


### PR DESCRIPTION
I included the handling of overlapping variants and of variations happening in the same reference position to be consistent with `bcftools consensus`' output.

Imported logic from `bcftools consensus`':
- *Overlapping variants:* https://github.com/samtools/bcftools/blob/df43fd4781298e961efc951ba33fc4cdcc165a19/consensus.c#L579
- *Same position insertions:* https://github.com/samtools/bcftools/blob/df43fd4781298e961efc951ba33fc4cdcc165a19/consensus.c#L723

